### PR TITLE
IssueID #51 フレーム入力して遷移時、フォーカスが外れる

### DIFF
--- a/src/canvastools/ts/CanvasTools/CanvasTools.Editor.ts
+++ b/src/canvastools/ts/CanvasTools/CanvasTools.Editor.ts
@@ -944,7 +944,12 @@ export class Editor {
 
         this.editorDiv.style.padding = `${vpadding}px ${hpadding}px`;
         // focus on the editor container div so that scroll bar can be used via arrow keys
-        this.editorContainerDiv.focus();
+        /**
+         * IssueID #51
+         * https://github.com/grabss/VsLT/issues/51
+         * ズーム時、フレーム移動時に強制的に画像内にフォーカスがあたるのでコメントアウト
+         */
+        // this.editorContainerDiv.focus();
     }
 
     /**


### PR DESCRIPTION
zoomEditorToScale関数の最後で
``this.editorContainerDiv.focus();``
の処理が走り、フレーム移動時やズーム時に強制的にeditorContainerDivにフォーカスが当たるようになってましたので、その部分をコメントアウトしました。

ご確認よろしくおねがいします